### PR TITLE
Move Github API call from backend to frontend

### DIFF
--- a/client/src/components/contribute/Contribute.jsx
+++ b/client/src/components/contribute/Contribute.jsx
@@ -47,6 +47,21 @@ const Contribute = () => {
       const response = await fetch(`${host}/api/v1/contribute`, settings)
       const responseData = await response.json()
       if (responseData.status === 'success') {
+        const username = contribution.username.replace(/\s+/g, '_').toLowerCase()
+        const topic = contribution.topic.replace(/\s+/g, '_').toLowerCase()
+        const today = new Date()
+        const date = today.getFullYear()+'-'+(today.getMonth()+1)+'-'+today.getDate()
+        const githubResponse = await fetch("https://api.github.com/repos/akatsuki-co/algoacademy/issues",
+        {
+          headers: {"Authorization": "token " + process.env.REACT_APP_GITHUB_TOKEN},
+          method: "POST",
+          body: JSON.stringify({
+            "title": `${date} ${username} - ${topic}`,
+            "body": markdown,
+            "labels": ["enhancement"]
+          })
+        })
+        const response = await githubResponse.json()
         history.push('/')
       } else {
         setContribution({ ...contribution, error: responseData.error })

--- a/controllers/contributeController.js
+++ b/controllers/contributeController.js
@@ -13,20 +13,8 @@ exports.contribute = catchAsync(async(req, res, next) => {
         if (err) throw err;
         console.log('File is created successfully.');
     })
-    const githubResponse = await fetch("https://api.github.com/repos/akatsuki-co/algoacademy/issues",
-        {
-            headers: {"Authorization": "token " + process.env.GITHUB_TOKEN},
-            method: "POST",
-            body: JSON.stringify({
-                "title": `${date} ${username} - ${topic}`,
-                "body": markdown,
-                "labels": ["enhancement"]
-            })
-        })
-    const response = await githubResponse.json()
     await res.status(200).json({
-        status: "success",
-        response: response
+        status: "success"
     })
 })
 


### PR DESCRIPTION
We were having issues with the Github Issues API in the backend in production so I moved the API call to the frontend React hoping this would fix the issue. 

I think the issue was something to do with NGINX and the rerouting of calls and getting caught in CORS but not sure because of the lack of error messages in the nginx error_logs. 

This merge would be a test to see if it would work in production.